### PR TITLE
refactor: replace NaN and Inf with their lowercase equivalents to fit numpy version >= 2.0

### DIFF
--- a/md_davis/hbond.py
+++ b/md_davis/hbond.py
@@ -201,7 +201,7 @@ class Contacts():
         atoms2 = sorted(atoms2, key=operator.itemgetter(0, 2, 1))
 
         matrix = numpy.empty(shape=(len(atoms1), len(atoms2)))
-        matrix[:] = numpy.NaN
+        matrix[:] = numpy.nan
         for group, atoms in atom_group2:
             j = atoms2.index(group)
             for index, row in atoms.iterrows():

--- a/md_davis/landscape/landscape.py
+++ b/md_davis/landscape/landscape.py
@@ -175,9 +175,9 @@ class Landscape:
 
     @staticmethod
     def minmax(array):
-        min_value, max_value = numpy.Inf, -numpy.Inf
+        min_value, max_value = numpy.inf, -numpy.inf
         for item in array:
-            if item != numpy.NaN:
+            if item != numpy.nan:
                 if item < min_value:
                     min_value = item
                 if item > max_value:
@@ -187,7 +187,7 @@ class Landscape:
     def energy_landscape(self, temperature=300):
         """ Perform Boltzmann inversion to get the energy landscape """
         def boltzmann_inversion(p, p_max, T=300):
-            return numpy.NaN if p <= 0 else -R*T*numpy.log(p/p_max)
+            return numpy.nan if p <= 0 else -R*T*numpy.log(p/p_max)
         boltzmann_inversion = numpy.vectorize(boltzmann_inversion)
 
         z_max = numpy.nanmax(self.zValues)

--- a/md_davis/plotting/plot_hbond.py
+++ b/md_davis/plotting/plot_hbond.py
@@ -54,7 +54,7 @@ def main(hbond_file, total_frames=None, cutoff=None, output='hbond_matrix.html',
     atoms2 = sorted(atoms2, key=operator.itemgetter(0, 2, 1))
 
     matrix = numpy.empty(shape=(len(atoms1), len(atoms2)))
-    matrix[:] = numpy.NaN
+    matrix[:] = numpy.nan
     for group, atoms in atom_group2:
         j = atoms2.index(group)
         for index, row in atoms.iterrows():


### PR DESCRIPTION
- `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.
- `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.

I have tested on numpy 1.26.3 and 2.2.0, both are OK.